### PR TITLE
Fix RBF transaction handling in wallet balance and coin selection

### DIFF
--- a/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
+++ b/BTCPayServer/Views/UIWallets/_WalletTransactionsList.cshtml
@@ -22,7 +22,13 @@
                 display-inline="true"/>
         </td>
         <td>
-            <vc:truncate-center text="@transaction.Id" link="@transaction.Link" classes="truncate-center-id" />
+            <div class="d-flex align-items-center gap-2">
+                <vc:truncate-center text="@transaction.Id" link="@transaction.Link" classes="truncate-center-id" />
+                @if (transaction.HistoryLine?.IsReplaced == true)
+                {
+                    <span class="badge bg-light text-muted" title="Transaction was replaced by RBF">RBF'd</span>
+                }
+            </div>
         </td>
         <td class="align-middle amount-col">
             <span data-sensitive class="text-@(transaction.Positive ? "success" : "danger")@(transaction.IsConfirmed ? "" : " opacity-50")">@transaction.Balance</span>


### PR DESCRIPTION
- Exclude RBF'd transactions from available balance calculation
- Filter out UTXOs from replaced transactions in coin selection
- Add visual indicator for replaced transactions in transaction history
- Implement caching for replaced transaction detection
- Prevent 'bad-txns-inputs-missingorspent' errors when attempting to spend

Fixes #6884